### PR TITLE
Add button next to each paragraph

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -5,16 +5,35 @@ import { createEditor } from 'slate';
 const Editor = ({ initialValue }) => {
   const editor = useMemo(() => withReact(createEditor()), []);
   const [value, setValue] = useState(initialValue);
+  const [highlightedParagraph, setHighlightedParagraph] = useState(null);
+
+  const renderElement = ({ attributes, children, element }) => {
+    if (element.type === 'paragraph') {
+      const isHighlighted = highlightedParagraph === element;
+      const style = {
+        outline: '1px solid black',
+        backgroundColor: isHighlighted ? 'yellow' : 'white',
+      };
+
+      const handleClick = () => {
+        console.log(element.children[0].text);
+        setHighlightedParagraph(isHighlighted ? null : element);
+      };
+
+      return (
+        <p {...attributes} style={style}>
+          {children}
+          <button onClick={handleClick}>Action</button>
+        </p>
+      );
+    }
+
+    return <p {...attributes}>{children}</p>;
+  };
 
   return (
     <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)}>
-      <Editable
-        renderElement={({ attributes, children }) => (
-          <p {...attributes} style={{ outline: '1px solid black' }}>
-            {children}
-          </p>
-        )}
-      />
+      <Editable renderElement={renderElement} />
     </Slate>
   );
 };


### PR DESCRIPTION
Fixes #4

Add button next to each paragraph in the editor

* Modify `src/components/Editor.js` to include a button labeled "Action" next to each paragraph.
* Add an `onClick` event handler to the button that logs the text of the paragraph to the console.
* Add an `onClick` event handler to the button that highlights the current paragraph by changing its background color and unhighlights any other paragraphs.
* Use a state variable to keep track of the currently highlighted paragraph.
* Update the `renderElement` function to render paragraphs with an outline style and include the button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realgenekim/slate-demo/issues/4?shareId=afcd0df3-b224-41f6-922d-94570430b33c).