### PR TITLE
Add BasicOutliner component to render a 2-level deep outline

### DIFF
--- a/src/components/BasicOutliner.js
+++ b/src/components/BasicOutliner.js
@@ -1,0 +1,60 @@
+import React, { useState, useMemo } from 'react';
+import { Slate, Editable, withReact } from 'slate-react';
+import { createEditor } from 'slate';
+
+const BasicOutliner = ({ initialValue }) => {
+  const editor = useMemo(() => withReact(createEditor()), []);
+  const [value, setValue] = useState(initialValue);
+
+  const renderElement = ({ attributes, children, element }) => {
+    if (element.type === 'list-item') {
+      return <li {...attributes}>{children}</li>;
+    } else if (element.type === 'unordered-list') {
+      return <ul {...attributes}>{children}</ul>;
+    }
+
+    return <p {...attributes}>{children}</p>;
+  };
+
+  return (
+    <Slate editor={editor} value={value} onChange={newValue => setValue(newValue)}>
+      <Editable renderElement={renderElement} />
+    </Slate>
+  );
+};
+
+const initialOutline = [
+  {
+    type: 'unordered-list',
+    children: [
+      {
+        type: 'list-item',
+        children: [{ text: 'First item' }],
+      },
+      {
+        type: 'list-item',
+        children: [
+          {
+            type: 'unordered-list',
+            children: [
+              {
+                type: 'list-item',
+                children: [{ text: 'Sub-item 1' }],
+              },
+              {
+                type: 'list-item',
+                children: [{ text: 'Sub-item 2' }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'list-item',
+        children: [{ text: 'Second item' }],
+      },
+    ],
+  },
+];
+
+export { BasicOutliner, initialOutline };

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Editor from './components/Editor';
-
-const initialValue = [
-  {
-    type: 'paragraph',
-    children: [{ text: 'First paragraph.' }],
-  },
-  {
-    type: 'paragraph',
-    children: [{ text: 'Second paragraph.' }],
-  },
-  {
-    type: 'paragraph',
-    children: [{ text: 'Third paragraph.' }],
-  },
-  {
-    type: 'paragraph',
-    children: [{ text: 'Fourth paragraph.' }],
-  },
-];
+import { BasicOutliner, initialOutline } from './components/BasicOutliner';
 
 ReactDOM.render(
   <React.StrictMode>
-    <Editor initialValue={initialValue} />
+    <BasicOutliner initialValue={initialOutline} />
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
Fixes #10

Add a new `BasicOutliner` component to render a 2-level deep outline using an unordered list.

* **New Component: BasicOutliner**
  - Create a new file `src/components/BasicOutliner.js`.
  - Implement the `BasicOutliner` component using `Slate` and `Editable` from `slate-react`.
  - Define a global data structure for a 2-level deep outline within the `BasicOutliner` component.
  - Include an initial outline structure with nested lists.

* **Update Index File**
  - Import the `BasicOutliner` component and initial outline from `src/components/BasicOutliner.js`.
  - Replace the `Editor` component with the `BasicOutliner` component in the `ReactDOM.render` call.
  - Update the initial value to be a 2-level deep outline.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realgenekim/slate-demo/issues/10?shareId=a9264185-801a-4afd-a776-4c05d4e5fb84).