### PR TITLE
Add move up/down buttons to list items in BasicOutliner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,3 +13,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 
 # Install global npm packages if needed
 RUN npm install -g typescript
+
+# gk: is startup performance ok?
+RUN npm install

--- a/src/components/BasicOutliner.js
+++ b/src/components/BasicOutliner.js
@@ -6,9 +6,29 @@ const BasicOutliner = ({ initialValue }) => {
   const editor = useMemo(() => withReact(createEditor()), []);
   const [value, setValue] = useState(initialValue);
 
+  const moveItem = (index, direction, parent) => {
+    const newValue = [...value];
+    const parentIndex = newValue.findIndex(item => item === parent);
+    const [movedItem] = newValue[parentIndex].children.splice(index, 1);
+    newValue[parentIndex].children.splice(index + direction, 0, movedItem);
+    setValue(newValue);
+  };
+
   const renderElement = ({ attributes, children, element }) => {
     if (element.type === 'list-item') {
-      return <li {...attributes}>{children}</li>;
+      const parent = value.find(item => item.children && item.children.includes(element));
+      if (!parent || !Array.isArray(parent.children)) {
+        console.error('Invalid parent or children structure', parent);
+        return <li {...attributes}>{children}</li>;
+      }
+      const index = parent.children.findIndex(item => item === element);
+      return (
+        <li {...attributes}>
+          {children}
+          <button onClick={() => moveItem(index, -1, parent)}>Move Up</button>
+          <button onClick={() => moveItem(index, 1, parent)}>Move Down</button>
+        </li>
+      );
     } else if (element.type === 'unordered-list') {
       return <ul {...attributes}>{children}</ul>;
     }


### PR DESCRIPTION
Fixes #12

Add "Move Up" and "Move Down" buttons to each list item in the outliner.

* Implement `moveItem` function to handle moving list items up or down within the same level.
* Update `renderElement` function to include "Move Up" and "Move Down" buttons for each list item.
* Ensure the `parent` object is defined and has a valid `children` array before accessing its properties in the `renderElement` function.
* Add error handling for invalid parent or children structure in the `renderElement` function.
* Add npm install command to Dockerfile for startup performance.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/realgenekim/slate-demo/issues/12?shareId=a4c6ce4b-5567-4e38-a2ac-6364307a9f3e).